### PR TITLE
correctly initialize admin inline-editing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+v4.2.1 (2025-xx-xx)
+===================
+
+- correctly initialize admin inline-editing
+
 v4.2.0 (2025-06-26)
 ===================
 

--- a/time_wizard/__init__.py
+++ b/time_wizard/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '4.2.0'
+__version__ = '4.2.1'

--- a/time_wizard/templates/admin/edit_inline/holiday_stacked.html
+++ b/time_wizard/templates/admin/edit_inline/holiday_stacked.html
@@ -1,9 +1,6 @@
 {% include "admin/polymorphic/edit_inline/stacked.html" %}
 <script type="text/javascript">
-  if (!$) {
-    var $ = django.jQuery
-  }
-
+(function ($) {
   const countryOptions = {{ countries }}
   const countryProvinceOptions = {{ country_provinces }}
 
@@ -76,14 +73,13 @@
         pSelect.append($('<option value="' + item + '"' + selected + '>' + item + '</option>'))
       })
     }
-    setupHolidayOptions(panel)
   }
 
   var setupHolidayEvents = function (panel) {
-    var changeHoliday = function () {
-      var selectedCountry = $(this).parent().find('.field-country').find('select')[0].value
-      var selectedProvince = $(this).parent().find('.field-province').find('select')[0].value
-      var hItem = $(this).parent().find('.field-holiday')
+    var changeHoliday = function (otherSelect) {
+      var selectedCountry = otherSelect.parent().find('.field-country').find('select')[0].value
+      var selectedProvince = otherSelect.parent().find('.field-province').find('select')[0].value
+      var hItem = otherSelect.parent().find('.field-holiday')
       var hXHR = new XMLHttpRequest()
       hXHR.onreadystatechange = function () {
         if (hXHR.readyState == XMLHttpRequest.DONE) {
@@ -94,8 +90,11 @@
       hXHR.open('GET', hURL)
       hXHR.send()
     }
-    panel.find('.field-country').change(changeHoliday)
-    panel.find('.field-province').change(changeHoliday)
+    panel.find('.field-country').change(function () {
+      setupProvinceOptions($(this).closest('div.inline-related')) // avoid using "empty" template ...
+      changeHoliday($(this))
+    })
+    panel.find('.field-province').change(function() { changeHoliday($(this)) })
   }
 
   var setupEvents = function (panel) {
@@ -109,9 +108,11 @@
       setupSelects($(this))
       setupCountryOptions($(this))
       setupProvinceOptions($(this))
+      setupHolidayOptions($(this))
       setupEvents($(this))
     })
   }
 
   setupTimeWizardHolidayRange()
+})(django.jQuery)
 </script>


### PR DESCRIPTION
fixes initializing when opening the admin via a plugin in django-cms.
Affects repos using this project inside the cms - not directly the admin in this overview here.